### PR TITLE
aliases on the top

### DIFF
--- a/lua/nvimTree/lua.lua
+++ b/lua/nvimTree/lua.lua
@@ -1,8 +1,11 @@
-vim.cmd [[packadd nvim-tree.lua]]
+local cmd = vim.cmd
+local g = vim.g
+
+cmd [[packadd nvim-tree.lua]]
 
 vim.o.termguicolors = true
 
-local g = vim.g
+
 
 g.nvim_tree_side = "left"
 g.nvim_tree_width = 25
@@ -85,7 +88,7 @@ g.nvim_tree_bindings = {
     ["q"] = get_lua_cb("close")
 }
 
-local cmd = vim.cmd
+
 
 cmd "hi NvimTreeFolderIcon guifg = #61afef"
 cmd "hi NvimTreeFolderName guifg = #61afef"


### PR DESCRIPTION
Why not make an alias of cmd first and then use cmd instead of vim.cmd